### PR TITLE
Fix out-of-date schedule for Spring CS 134

### DIFF
--- a/teaching/spring-2025-cs134/schedule.html
+++ b/teaching/spring-2025-cs134/schedule.html
@@ -119,19 +119,19 @@ overview: true
     <tr>
         <td>Lecture 17</td>
         <td>May 27</td>
-        <td>Optimistic Concurrency Control, Tail Latency</td>
+        <td>Azure Storage</td>
         <td></td>
     </tr>
     <tr>
         <td>Lecture 18</td>
         <td>May 29</td>
-        <td>Azure Storage</td>
+        <td>Google Spanner</td>
         <td></td>
     </tr>
     <tr>
         <td>Lecture 19</td>
         <td>June 3</td>
-        <td>Google Spanner</td>
+        <td>Microservices and Mucache</td>
         <td></td>
     </tr>
     <tr>


### PR DESCRIPTION
I realized when I clicked on a recording and it didn't match up with the dates on the page