### PR TITLE
Specify Discussion Sections for TAs/LAs

### DIFF
--- a/teaching/distributed-systems.html
+++ b/teaching/distributed-systems.html
@@ -23,19 +23,19 @@ overview: true
 <b>TAS:</b> 
 <ul>
     <li>Kalon Kelley (he/him)
-        (<a href="mailto:klkelley@g.ucla.edu">klkelley@g.ucla.edu</a>)
+        (<a href="mailto:klkelley@g.ucla.edu">klkelley@g.ucla.edu</a>) (Disc 1A, 2pm)
     </li>
     <li>Teng (Sebastian) Jiang (he/him) 
-        (<a href="mailto:sebtj@ucla.edu">sebtj@ucla.edu</a>)
+        (<a href="mailto:sebtj@ucla.edu">sebtj@ucla.edu</a>) (Disc 1B, 12pm)
     </li>
 </ul>
 <b>LAs:</b>
 <ul>
     <li>Alec Machlis (he/him) 
-        (<a href="mailto:alecmachlis@g.ucla.edu">alecmachlis@g.ucla.edu</a>)
+        (<a href="mailto:alecmachlis@g.ucla.edu">alecmachlis@g.ucla.edu</a>) (Disc 1B, 12pm)
     </li>
     <li>Peter Nguyen (he/him)
-        (<a href="mailto:petern0408@g.ucla.edu">petern0408@g.ucla.edu</a>)
+        (<a href="mailto:petern0408@g.ucla.edu">petern0408@g.ucla.edu</a>) (Disc 1A, 2pm)
     </li>
 </ul>
 <b>Lecture Time & Location:</b> Tuesdays/Thursdays 4pm-5:50pm -- Kinsey Pavilion 1200B</br>


### PR DESCRIPTION
From a student's perspective, I like it when there's an easy way to look up the name of my TA/LA, so I think it's helpful to specify the discussion sections we're assigned to on the website.

I specified the times because I think it's easy to mistake that 1A is the earlier one and 1B is the later, but that's not the case this quarter for some reason 🤷.