### PR TITLE
Update grading distribution and add note about discussion attendance

### DIFF
--- a/teaching/distributed-systems.html
+++ b/teaching/distributed-systems.html
@@ -77,7 +77,7 @@ Distributed systems enable developers to leverage compute and storage resources 
     <ul>
         <li>57% Programming Assignments (10% for Assignment 1, 15% for Assignment 2, 15% for Assignment 3, and 17% for Assignment 4)</li>
         <li>40% Final Exam</li>
-        <li>3% Discussion Attendance (1% for attending each of the first 3 discussion sections. Send a private Piazza post to instructors if you have a conflict to discuss)</li>
+        <li>3% Discussion Attendance (1% for attending each of the first 3 discussion sections. You can attend either one (no need to ask). Send a private Piazza post to discuss with instructors if you have a conflict with both for the quarter or even just a single day)</li>
     </ul>
 </p>
 

--- a/teaching/distributed-systems.html
+++ b/teaching/distributed-systems.html
@@ -75,9 +75,9 @@ Distributed systems enable developers to leverage compute and storage resources 
 
 <p class="homepage">
     <ul>
-        <li>70% Programming Assignments (10% for Assignment 1, 20% each for Assignments 2-4)</li>
-        <li>30% Final Exam</li>
-        <li>Bonus: If you attend the first three discussion sections you can take some weight of the exam: 6% Discussion Participation and 24% Exam.</li>
+        <li>57% Programming Assignments (10% for Assignment 1, 15% for Assignment 2, 15% for Assignment 3, and 17% for Assignment 4)</li>
+        <li>40% Final Exam</li>
+        <li>3% Discussion Attendance (1% for attending each of the first 3 discussion sections. Send a private Piazza post to instructors if you have a conflict to discuss)</li>
     </ul>
 </p>
 


### PR DESCRIPTION
Update the grading distribution based on what the instructional team agreed on.

Note that the breakdown of the 57% for programming assignments was discussed over Discord after the meeting. Double-check you're okay with it, since you haven't acknowledged it in Discord yet.