### PR TITLE
Remove 'along with a note about how work was divided' note from CS 134 assignments section

### DIFF
--- a/teaching/distributed-systems.html
+++ b/teaching/distributed-systems.html
@@ -98,7 +98,7 @@ need to know Go entering this class, but you should have familiarity with concur
 <p class="homepage">
 The course will include four heavy programming assignments which collectively focus on building a fault-tolerant, sharded key/value store. The assignments will be implemented using the 
 <a href="https://go.dev/">Go programming language</a>. 
-The first lab must be completed individually (as it provides an introduction to the Go programming environment, and how we will use it in this course). The remaining three labs may be completed individually, or in groups of two students (each group will turn in one solution, along with a note about how work was divided). Note that expectations are the same for individuals or groups. 
+The first lab must be completed individually (as it provides an introduction to the Go programming environment, and how we will use it in this course). The remaining three labs may be completed individually, or in groups of two students (each group will turn in one solution). Note that expectations are the same for individuals or groups. 
 If you need help to find a partner, please come to discussion section and talk to folks. Alternatively, you can post about partner searchers on Piazza or email the TA who will try and pair you with someone. Also note that the same groups will be used for assignments 2-4. Assignments are due by 10pm (PDT) on the listed due dates. Each assignment will take <strong>a lot of time</strong> (mostly spent designing solutions and debugging), so please start early!
 </p>
 


### PR DESCRIPTION
Apparently has been here since before last year's offering. Let's remove it.